### PR TITLE
SPDPP-389 resolve issues with uri's containing /application, ensure t…

### DIFF
--- a/pill-press-app/ClientApp/src/app/applications/authorized-owner/authorized-application-review/authorized-application-review.component.ts
+++ b/pill-press-app/ClientApp/src/app/applications/authorized-owner/authorized-application-review/authorized-application-review.component.ts
@@ -39,7 +39,7 @@ export class AuthorizedApplicationReviewComponent implements OnInit {
     private dynamicsDataService: DynamicsDataService,
     private applicationDataService: ApplicationDataService) {
     this.waiverId = this.route.snapshot.params.id;
-    this.attachmentURL = `api/file/${this.waiverId}/attachments/application`;
+    this.attachmentURL = `api/file/${this.waiverId}/attachments/incident`;
   }
 
   ngOnInit() {

--- a/pill-press-app/ClientApp/src/app/applications/waiver/waiver-application/waiver-application.component.html
+++ b/pill-press-app/ClientApp/src/app/applications/waiver/waiver-application/waiver-application.component.html
@@ -145,7 +145,7 @@
 
           <section>
             <label for="">If you have additional supporting documents, please upload them below.</label>
-            <app-file-uploader documentType="Waiver Documents" entityName="application" [entityId]="waiverId" fileTypes="FILE MUST BE IN DOC, XLS, PDF, JPG OR PNG"
+            <app-file-uploader documentType="Waiver Documents" entityName="incident" [entityId]="waiverId" fileTypes="FILE MUST BE IN DOC, XLS, PDF, JPG OR PNG"
               [extensions]="['pdf', 'jpg', 'jpeg', 'png', 'xls', 'doc']"></app-file-uploader>
           </section>
         </section>

--- a/pill-press-app/ClientApp/src/app/applications/waiver/waiver-review/waiver-review.component.ts
+++ b/pill-press-app/ClientApp/src/app/applications/waiver/waiver-review/waiver-review.component.ts
@@ -36,7 +36,7 @@ export class WaiverReviewComponent implements OnInit {
     private dynamicsDataService: DynamicsDataService,
     private applicationDataService: ApplicationDataService) {
     this.waiverId = this.route.snapshot.params.id;
-    this.attachmentURL = `api/file/${this.waiverId}/attachments/application`;
+    this.attachmentURL = `api/file/${this.waiverId}/attachments/incident`;
   }
 
   ngOnInit() {

--- a/pill-press-app/Controllers/FileController.cs
+++ b/pill-press-app/Controllers/FileController.cs
@@ -154,7 +154,7 @@ namespace Gov.Jag.PillPressRegistry.Public.Controllers
             var id = Guid.Parse(entityId);
             switch (entityName.ToLower())
             {
-                case "application":
+                case "incident":
                     var application =  _dynamicsClient.GetApplicationById(id);
                     result = application != null && CurrentUserHasAccessToApplicationOwnedBy(application._customeridValue);
                     break;
@@ -189,7 +189,7 @@ namespace Gov.Jag.PillPressRegistry.Public.Controllers
                     var contact = await _dynamicsClient.GetContactById(Guid.Parse(entityId));
                     folderName = GetContactFolderName(contact);
                     break;
-                case "application":
+                case "incident":
                     var incident =  _dynamicsClient.GetApplicationById(Guid.Parse(entityId));
                     folderName = GetApplicationFolderName(incident);
                     break;
@@ -221,7 +221,7 @@ namespace Gov.Jag.PillPressRegistry.Public.Controllers
                         throw (odee);
                     }
                     break;
-                case "application":
+                case "incident":
                     var patchIncident = new MicrosoftDynamicsCRMincident();
                     try
                     {
@@ -375,7 +375,7 @@ namespace Gov.Jag.PillPressRegistry.Public.Controllers
             var listTitle = "";
             switch (entityName.ToLower())
             {
-                case "application":
+                case "incident":
                     listTitle = SharePointFileManager.ApplicationDocumentListTitle;
                     break;
                 case "contact":
@@ -395,7 +395,7 @@ namespace Gov.Jag.PillPressRegistry.Public.Controllers
             var listTitle = "";
             switch (entityName.ToLower())
             {
-                case "application":
+                case "incident":
                     listTitle = SharePointFileManager.ApplicationDocumentListTitle;
                     break;
                 case "contact":

--- a/pill-press-interfaces/SharePoint/SharePointFileManager.cs
+++ b/pill-press-interfaces/SharePoint/SharePointFileManager.cs
@@ -18,8 +18,8 @@ namespace Gov.Jag.PillPressRegistry.Interfaces
     public class SharePointFileManager
     {
         public const string DefaultDocumentListTitle = "Account";
-        public const string ApplicationDocumentListTitle = "Application";
-        public const string ApplicationDocumentUrlTitle = "adoxio_application";
+        public const string ApplicationDocumentListTitle = "incident";
+        public const string ApplicationDocumentUrlTitle = "incident";
         public const string ContactDocumentListTitle = "contact";
         public const string WorkertDocumentListTitle = "Worker Qualification";
 


### PR DESCRIPTION
…hat /incident is used to reflect the updated naming on Sharepoint. Fix made to both the get and set uri's for file gets/sets.

Current state is a 403 from sub-folder creation (a folder within the /incident folder named after the GUID).