### PR TITLE
 SPDPP-681 Add support for SharePoint installations with no webname (…

### DIFF
--- a/pill-press-app/Controllers/ApplicationController.cs
+++ b/pill-press-app/Controllers/ApplicationController.cs
@@ -910,7 +910,13 @@ namespace Gov.Jag.PillPressRegistry.Public.Controllers
                         }
                     }
 
-                    string serverRelativeUrl = "/sites/" + _sharePointFileManager.WebName + "/" + _sharePointFileManager.GetServerRelativeURL(SharePointFileManager.AccountDocumentListTitle, account.GetSharePointFolderName() + $"/{filePrefix}{certificateName}.pdf");
+                    string serverRelativeUrl = "";
+
+                    if (! string.IsNullOrEmpty(_sharePointFileManager.WebName))
+                    {
+                        serverRelativeUrl += "/sites/" + _sharePointFileManager.WebName;
+                    }
+                    serverRelativeUrl += "/" + _sharePointFileManager.GetServerRelativeURL(SharePointFileManager.AccountDocumentListTitle, account.GetSharePointFolderName() + $"/{filePrefix}{certificateName}.pdf");
 
                     try
                     {


### PR DESCRIPTION
…#168)

* SPDPP-573 changes to download certificate code

* SPDPP-681 Add support for SharePoint installations with no webname